### PR TITLE
Form helpers.

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -147,3 +147,53 @@ Params:
 - $name: The name of the Input key
 - $default: The default value to use when the Input value is not found
 - e.g. {{ val('username', 'Anonymous') }}
+
+## Form Functions ##
+
+The following form helpers are included to make sure that building forms in twig views is as painless as possible.
+
+All functions take the same arguments as their `Laravel\Form` counterpart, you can find information on that at http://laravel.com/docs/views/forms, and in the form class API at http://laravel.com/api/class-Laravel.Form.html.
+
+```twig
+{#  Form::open() #}
+{{ form_open }}
+
+{# Form::open_secure() #}
+{{ form_open_secure() }}
+
+{# Form::open_for_files() #}
+{{ form_open_for_files() }}
+
+{# Form::open_secure_for_files #}
+{{ form_open_secure_for_files() }}
+
+{# Form::close() #}
+{{ form_close() }}
+
+{# Form::label() #}
+{{ form_label() }}
+
+{# Form::text() #}
+{{ form_text() }}
+
+{# Form::submit() #}
+{{ form_submit() }}
+
+{# Form::textarea() #}
+{{ form_textarea() }}
+
+{# Form::hidden() #}
+{{ form_hidden() }}
+
+{# Form::token() #}
+{{ form_token() }}
+
+{# Form::checkbox() #}
+{{ form_checkbox() }}
+
+{# Form::radio() #}
+{{ form_radio() }}
+
+{# Form::select #}
+{{ form_select() }}
+```

--- a/config/twig.php
+++ b/config/twig.php
@@ -23,6 +23,21 @@ return array(
         'secure_link' => array('function' => 'twig_fn_secure_link', 'params' => array('is_safe' => array('html'))),
         'image' => array('function' => 'twig_fn_image', 'params' => array('is_safe' => array('html'))),
         'email' => array('function' => 'twig_fn_email', 'params' => array('is_safe' => array('html'))),
+        'form_open' => array('function' => 'twig_fn_form_open', 'params' => array('is_safe' => array('html'))),
+        'form_open_secure' => array('function' => 'twig_fn_form_open_secure', 'params' => array('is_safe' => array('html'))),
+        'form_open_for_files' => array('function' => 'twig_fn_form_open_for_files', 'params' => array('is_safe' => array('html'))),
+        'form_open_secure_for_files' => array('function' => 'twig_fn_form_open_secure_for_files', 'params' => array('is_safe' => array('html'))),
+        'form_close' => array('function' => 'twig_fn_form_close', 'params' => array('is_safe' => array('html'))),
+        'form_label' => array('function' => 'twig_fn_form_label', 'params' => array('is_safe' => array('html'))),
+        'form_text' => array('function' => 'twig_fn_form_text', 'params' => array('is_safe' => array('html'))),
+        'form_submit' => array('function' => 'twig_fn_form_submit', 'params' => array('is_safe' => array('html'))),
+        'form_textarea' => array('function' => 'twig_fn_form_textarea', 'params' => array('is_safe' => array('html'))),
+        'form_hidden' => array('function' => 'twig_fn_form_hidden', 'params' => array('is_safe' => array('html'))),
+        'form_token' => array('function' => 'twig_fn_form_token', 'params' => array('is_safe' => array('html'))),
+        'form_checkbox' => array('function' => 'twig_fn_form_checkbox', 'params' => array('is_safe' => array('html'))),
+        'form_radio' => array('function' => 'twig_fn_form_radio', 'params' => array('is_safe' => array('html'))),
+        'form_select' => array('function' => 'twig_fn_form_select', 'params' => array('is_safe' => array('html'))),
+
     ),
 
     // Twig filters. These are used in the Twig templates.

--- a/twigfunctions.php
+++ b/twigfunctions.php
@@ -6,6 +6,7 @@ use Laravel\Input;
 use Laravel\Lang;
 use Laravel\Str;
 use Laravel\URL;
+use Laravel\Form;
 
 /**
  * Read and return a config value
@@ -293,6 +294,82 @@ function twig_fn_image($file, $alt = '', $params = '')
 function twig_fn_email($email)
 {
 	return HTML::email($email);
+}
+
+/**
+ * Laravel form API helpers - generate forms with even less Twig code!
+ *
+ * @see http://laravel.com/docs/views/forms
+ */
+
+function twig_fn_form_open($action = null, $method = 'POST', $attributes = array(), $https = FALSE)
+{
+	return Form::open($action, $method, $attributes, $https);
+}
+
+function twig_fn_form_open_secure($action = null, $method = 'POST', $attributes = array())
+{
+	return Form::open_secure($action, $method, $attributes);
+}
+
+function twig_fn_form_open_for_files($action = null, $method = 'POST', $attributes = array())
+{
+	return Form::open_for_files($action, $method, $attributes);
+}
+
+function twig_fn_form_open_secure_for_files($action = null, $method = 'POST', $attributes = array())
+{
+	return Form::open_secure_for_files($action, $method, $attributes);
+}
+
+function twig_fn_form_close()
+{
+	return Form::close();
+}
+
+function twig_fn_form_label($name, $text, $attributes = array())
+{
+	return Form::label($name, $text, $attributes);
+}
+
+function twig_fn_form_text($name, $value = null, $attributes = array())
+{
+	return Form::text($name, $value, $attributes);
+}
+
+function twig_fn_form_textarea($name, $value = null, $attributes = array())
+{
+	return Form::textarea($name, $value, $attributes);
+}
+
+function twig_fn_form_hidden($name, $value = null, $attributes = array())
+{
+	return Form::hidden($name, $value, $attributes);
+}
+
+function twig_fn_form_submit($text = 'Submit')
+{
+	return Form::submit($text);
+}
+
+function twig_fn_form_token()
+{
+	return Form::token();
+}
+
+function twig_fn_form_checkbox($name, $value = 1, $checked = false, $attributes = array())
+{
+	return Form::checkbox($name, $value, $checked, $attributes);
+}
+
+function twig_fn_form_radio($name, $value = 1, $checked = false, $attributes = array())
+{
+	return Form::radio($name, $value, $checked, $attributes);
+}
+
+function twig_fn_form_select($name, $options = array(), $selected = null, $attributes = array())
+{
+	return Form::select($name, $options, $selected, $attributes);
 }
 
 


### PR DESCRIPTION
I've written in most of the static form functions as helpers in Twig, hopefully this should make views a lot cleaner and remove the need to define forms in controllers or call the `Form` functions using the 'call any function' function.

I haven't included any documentation of these (yet) but i will in a future pull request (soon). Let me know if you'd prefer this to be done before merging this one.
